### PR TITLE
Bugfix for interfaces and abstract classes

### DIFF
--- a/patterns/php.yml
+++ b/patterns/php.yml
@@ -51,7 +51,7 @@
   inspector : php
 -
   message   : Empty Entities: Empty Method
-  xpath     : //node:Stmt_ClassMethod[count(subNode:stmts/scalar:array/*) = 0]/subNode:name/scalar:string
+  xpath     : //node:Stmt_ClassMethod[subNode:stmts/scalar:array and count(subNode:stmts/scalar:array/*) = 0]/subNode:name/scalar:string
   inspector : php
 -
   message   : Expression Issues: Expression is Always True


### PR DESCRIPTION
Bug:
"Empty Entities: Empty Method" violations for empty methods in interfaces and abstract classes.

Problem:
The count method return 0 also if the element does not exists.

Fix:
Check first if the node exists.

Test:
There is currently not tests in the project. So here is my test class.
interface TestInterface {
    public function test();
}

abstract class TestAbstract
{
    abstract public function test();
}

class Test
{
    public function test() { }
}
